### PR TITLE
Removed empty log message to prevent script crash in Upload-C3DScene

### DIFF
--- a/C3DUploadTools/Public/Upload-C3DScene.ps1
+++ b/C3DUploadTools/Public/Upload-C3DScene.ps1
@@ -353,7 +353,6 @@ function Upload-C3DScene {
         
         if (-not $DryRun) {
             Write-C3DLog -Message "Script completed in $([math]::Round($totalDuration, 2)) seconds" -Level Info
-            Write-C3DLog -Message "" -Level Info
             Write-C3DLog -Message "Next Steps:" -Level Info
             Write-C3DLog -Message "1. You can now upload dynamic objects using Upload-C3DObject" -Level Info
             Write-C3DLog -Message "2. You'll need the scene ID from the upload response" -Level Info


### PR DESCRIPTION
Removed empty log message to prevent script crash on Windows in Upload-C3DScene.ps1 


<img width="961" height="563" alt="crash" src="https://github.com/user-attachments/assets/a70aaed5-cac2-44d1-9708-8a3410a385dc" />
