### PR TITLE
Fix dynamic object ID to use UUID instead of mesh name

### DIFF
--- a/C3DUploadTools/Public/Upload-C3DObject.ps1
+++ b/C3DUploadTools/Public/Upload-C3DObject.ps1
@@ -232,11 +232,11 @@ function Upload-C3DObject {
         $SceneId = ConvertTo-C3DLowerUuid -Uuid $SceneId -FieldName 'SceneId'
         Write-C3DLog -Message "Scene ID: $SceneId" -Level Debug
         
-        # Handle Object ID - validate UUID format only if explicitly provided
+        # Handle Object ID - generate UUID if not explicitly provided (matches Unity SDK behavior)
+        # Unity SDK uses GUID for id, separate from mesh name
         if (-not $ObjectId) {
-            # Use object filename as ID (bash script behavior)
-            $ObjectId = $ObjectFilename
-            Write-C3DLog -Message "Object ID not provided, using derived ID: $ObjectId" -Level Debug
+            $ObjectId = [guid]::NewGuid().ToString().ToLower()
+            Write-C3DLog -Message "Object ID not provided, generated UUID: $ObjectId" -Level Debug
         } else {
             # Validate UUID format for explicitly provided ObjectId
             if (-not (Test-C3DUuidFormat -Uuid $ObjectId -FieldName 'ObjectId')) {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 3. Upload object manifest to display objects in dashboard
 4. Object manifests are automatically generated but can be manually edited before upload
 
+### Object Manifest Structure
+
+The object manifest follows Unity SDK conventions. Each object entry has:
+- `id`: A unique UUID identifying this object instance (auto-generated if not provided)
+- `mesh`: The name of the 3D model file (e.g., "cube" for cube.gltf/cube.bin)
+- `name`: Display name for the object (defaults to mesh name)
+- `scaleCustom`: Scale factors [x, y, z]
+- `initialPosition`: Starting position [x, y, z]
+- `initialRotation`: Quaternion rotation [x, y, z, w]
+
+**Important:** The `id` field is a UUID, not the mesh name. Multiple objects can share the same `mesh` but must have unique `id` values. When no `--object_id` is provided, scripts auto-generate a UUID.
+
 ### Texture Format Support
 
 - **Scene uploads** support PNG, JPG, JPEG, and WEBP image files

--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ Upload-C3DObject -ObjectFilename <name> -ObjectDirectory <directory> [-SceneId <
 - `<filename>.gltf`, `<filename>.bin`
 - `cvr_object_thumbnail.png` (optional, recommended)
 
+**Object Manifest:**
+When you upload an object, a manifest file (`{scene_id}_object_manifest.json`) is automatically created/updated. Each object entry includes:
+- A unique `id` (UUID) - auto-generated for each upload
+- `mesh` - the filename of the 3D model
+- `name` - display name in the dashboard
+- Transform data (position, rotation, scale)
+
+You can edit the manifest file before running `upload-object-manifest.sh` to customize positions or add multiple instances of the same object.
+
 **Examples:**
 ```bash
 # Upload object (scene ID from environment)

--- a/upload-object.sh
+++ b/upload-object.sh
@@ -167,12 +167,11 @@ EOF
 
   log_info "Using environment: $ENVIRONMENT"
 
-  # if object_id is not provided, it will be created from the object_filename
+  # if object_id is not provided, generate a UUID (matches Unity SDK behavior)
+  # Unity SDK uses GUID for id, separate from mesh name
   if [[ -z "$OBJECT_ID" ]]; then
-    OBJECT_ID=$(basename "$OBJECT_FILENAME")
-    # OBJECT_ID="RANDOM_SOMETHING_1234"
-    # make the OBJECT_ID a string as the current milliseconds timestamp to ensure uniqueness
-    log_debug "Object ID not provided, using derived ID: $OBJECT_ID"
+    OBJECT_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+    log_debug "Object ID not provided, generated UUID: $OBJECT_ID"
   fi
 
   # Log the parameters


### PR DESCRIPTION
## Summary
- Changed both bash and PowerShell scripts to generate a UUID for the object manifest `id` field when no `--object_id` is provided
- Matches Unity SDK behavior where `id` is a unique identifier and `mesh` is the object filename
- Bash: uses `uuidgen` with lowercase conversion
- PowerShell: uses `[guid]::NewGuid().ToString().ToLower()`

## Test plan
- [x] Test bash script object upload without `--object_id` flag - verify manifest contains UUID for `id`
- [x] Test PowerShell object upload without `-ObjectId` param - verify manifest contains UUID for `id`
- [x] Verify uploaded objects appear correctly in C3D dashboard