### PR TITLE
Fix Content→Body property mismatch in Get-C3DObjects and Upload-C3DObjectManifest

### DIFF
--- a/C3DUploadTools/Private/Api/Send-C3DHttpRequest.ps1
+++ b/C3DUploadTools/Private/Api/Send-C3DHttpRequest.ps1
@@ -193,12 +193,17 @@ function Send-C3DHttpRequest {
 
             if ($response) {
                 $statusCode = [int]$response.StatusCode
-                $responseStream = $response.GetResponseStream()
-                $reader = New-Object System.IO.StreamReader($responseStream)
-                $responseContent = $reader.ReadToEnd()
-                $reader.Close()
-                $responseStream.Close()
-                $response.Close()
+                $statusDescription = $response.StatusDescription
+                $responseContent = $null
+                try {
+                    $responseStream = $response.GetResponseStream()
+                    $reader = New-Object System.IO.StreamReader($responseStream)
+                    $responseContent = $reader.ReadToEnd()
+                    $reader.Dispose()
+                    $responseStream.Dispose()
+                } finally {
+                    $response.Dispose()
+                }
 
                 Write-C3DLog -Message "WebRequest failed with HTTP $statusCode" -Level Error
 
@@ -206,7 +211,7 @@ function Send-C3DHttpRequest {
                     StatusCode = $statusCode
                     Content = $responseContent
                     Headers = @{}
-                    StatusDescription = $response.StatusDescription
+                    StatusDescription = $statusDescription
                 }
             } else {
                 throw $webException

--- a/C3DUploadTools/Private/Api/Send-C3DHttpRequest.ps1
+++ b/C3DUploadTools/Private/Api/Send-C3DHttpRequest.ps1
@@ -305,7 +305,13 @@ function ConvertTo-C3DApiResponse {
         Headers = $HttpResponse.Headers
         TimingMs = $TimingMs
         Success = $isSuccess
-        Error = if ($isSuccess) { $null } else { $ErrorMessage -or "HTTP $($HttpResponse.StatusCode): $($HttpResponse.StatusDescription)" }
+        Error = if ($isSuccess) {
+            $null
+        } elseif ($ErrorMessage) {
+            $ErrorMessage
+        } else {
+            "HTTP $($HttpResponse.StatusCode): $($HttpResponse.StatusDescription)"
+        }
         RawResponse = $HttpResponse
     }
 }

--- a/C3DUploadTools/Public/Get-C3DObjects.ps1
+++ b/C3DUploadTools/Public/Get-C3DObjects.ps1
@@ -150,10 +150,10 @@ function Get-C3DObjects {
         
         $sceneResponse = Invoke-C3DApiRequest -Uri $sceneUrl -Method GET
         if ($sceneResponse.StatusCode -ne 200) {
-            throw "Failed to get scene info. HTTP $($sceneResponse.StatusCode): $($sceneResponse.Content)"
+            throw "Failed to get scene info. HTTP $($sceneResponse.StatusCode): $($sceneResponse.Body)"
         }
-        
-        $sceneData = $sceneResponse.Content | ConvertFrom-Json
+
+        $sceneData = $sceneResponse.Body | ConvertFrom-Json
         $latestVersion = $sceneData.versions | Sort-Object versionNumber | Select-Object -Last 1
         
         if (-not $latestVersion) {
@@ -169,10 +169,10 @@ function Get-C3DObjects {
         
         $objectsResponse = Invoke-C3DApiRequest -Uri $objectsUrl -Method GET
         if ($objectsResponse.StatusCode -ne 200) {
-            throw "Failed to get objects. HTTP $($objectsResponse.StatusCode): $($objectsResponse.Content)"
+            throw "Failed to get objects. HTTP $($objectsResponse.StatusCode): $($objectsResponse.Body)"
         }
-        
-        $objectsData = $objectsResponse.Content | ConvertFrom-Json
+
+        $objectsData = $objectsResponse.Body | ConvertFrom-Json
         
         # Display results
         Write-Host "Scene Objects:" -ForegroundColor Cyan

--- a/C3DUploadTools/Public/Get-C3DObjects.ps1
+++ b/C3DUploadTools/Public/Get-C3DObjects.ps1
@@ -150,7 +150,8 @@ function Get-C3DObjects {
         
         $sceneResponse = Invoke-C3DApiRequest -Uri $sceneUrl -Method GET
         if ($sceneResponse.StatusCode -ne 200) {
-            throw "Failed to get scene info. HTTP $($sceneResponse.StatusCode): $($sceneResponse.Body)"
+            $detail = if ($sceneResponse.Body) { $sceneResponse.Body } else { $sceneResponse.Error }
+            throw "Failed to get scene info. HTTP $($sceneResponse.StatusCode): $detail"
         }
 
         $sceneData = $sceneResponse.Body | ConvertFrom-Json
@@ -169,7 +170,8 @@ function Get-C3DObjects {
         
         $objectsResponse = Invoke-C3DApiRequest -Uri $objectsUrl -Method GET
         if ($objectsResponse.StatusCode -ne 200) {
-            throw "Failed to get objects. HTTP $($objectsResponse.StatusCode): $($objectsResponse.Body)"
+            $detail = if ($objectsResponse.Body) { $objectsResponse.Body } else { $objectsResponse.Error }
+            throw "Failed to get objects. HTTP $($objectsResponse.StatusCode): $detail"
         }
 
         $objectsData = $objectsResponse.Body | ConvertFrom-Json

--- a/C3DUploadTools/Public/Upload-C3DObjectManifest.ps1
+++ b/C3DUploadTools/Public/Upload-C3DObjectManifest.ps1
@@ -149,14 +149,14 @@ function Upload-C3DObjectManifest {
         
         if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300) {
             Write-C3DLog -Message "Object manifest uploaded successfully" -Level Info
-            if ($response.Content) {
-                $responseObj = $response.Content | ConvertFrom-Json -ErrorAction SilentlyContinue
+            if ($response.Body) {
+                $responseObj = $response.Body | ConvertFrom-Json -ErrorAction SilentlyContinue
                 if ($responseObj) {
                     Write-C3DLog -Message "Response: $($responseObj | ConvertTo-Json -Compress)" -Level Debug
                 }
             }
         } else {
-            throw "Upload failed with HTTP $($response.StatusCode): $($response.Content)"
+            throw "Upload failed with HTTP $($response.StatusCode): $($response.Body)"
         }
         
         # Log execution time


### PR DESCRIPTION
## Summary

Fixes a class of bug where callers of `Invoke-C3DApiRequest` read `.Content` from the response object, but `ConvertTo-C3DApiResponse` (the standardizer in `Send-C3DHttpRequest.ps1:305`) exposes the body on `.Body`, not `.Content`. JSON parsing therefore silently produced null/empty data on every call.

**Four commits in this PR:**

1. **`7c5c48b` — Fix `Get-C3DObjects` Content→Body (T1.1, original scope)**
   - 4 replacements in `Get-C3DObjects.ps1:153,156,172,175`.

2. **`e7a0923` — Cherry-pick of `3b0ada1` (added after Codex review)**
   - Same fix applied to `Upload-C3DObjectManifest.ps1`.
   - Captures `$response.StatusDescription` before `$response.Dispose()` in the HttpWebRequest catch block (use-after-dispose fix).
   - Note: PR #10 has already merged to develop and includes the same content. Git's 3-way merge will detect identical blobs and no-op these hunks; the commit becomes effectively empty on the develop side.

3. **`8d75fc8` — Fall back to `.Error` when response `.Body` is null (added after Codex review)**
   - If `Invoke-C3DApiRequest` returns a normalized transport-error response (`StatusCode = $null`, `Body = $null`, `Error = "<exception message>"`), the previous throw rendered as the useless `"HTTP : "`. Now falls back to `.Error` when `Body` is missing, producing actionable output like `"HTTP : Connection refused"`.

4. **`b6e1f61` — Fix `.Error` populated via boolean `-or` instead of fallback (added after /review)**
   - `ConvertTo-C3DApiResponse` built `.Error` with `$ErrorMessage -or "HTTP ..."`. PowerShell's `-or` is a **boolean** operator — `"Connection refused" -or "fallback"` returns `$true`, not the string. So every non-2xx response was emitting `.Error = $true`.
   - This was masked until commit `8d75fc8` (above) started concatenating `.Error` into throw messages — without this fix, transport errors would render as `"HTTP : True"` instead of the intended exception text.
   - Replaced with an explicit `if/elseif/else` chain. Verified behaviour:
     - `$ErrorMessage = "Connection refused"` → `"Connection refused"` (String)
     - `$ErrorMessage = ""` or `$null` → `"HTTP 503: Service Unavailable"` (String)

## Test plan

- [x] `grep -rn '\.Content' C3DUploadTools/Public/*.ps1` returns no problematic matches
- [x] `git log develop..HEAD` shows the 4 expected commits
- [x] Sanity-checked the boolean-OR fix in `pwsh`: old → `Boolean True`, new → `String "Connection refused"`
- [ ] Manual smoke test: `Get-C3DObjects -SceneId <real> -Environment dev` returns parsed JSON instead of $null
- [ ] Manual smoke test: `Upload-C3DObjectManifest -SceneId <real>` no longer throws after a successful 201
- [ ] Manual smoke test (transport error): `Get-C3DObjects -Environment dev` with no network → throw message reads `"HTTP : Connection refused"` (or similar), not `"HTTP : True"` and not `"HTTP : "`

## Review history

- Initial scope: only fixed `Get-C3DObjects.ps1` (commit `7c5c48b`).
- **Codex review** (via `/codex:rescue`) verified the 4 original replacements but found:
  1. Same bug class still present in `Upload-C3DObjectManifest.ps1` on this branch (blocking) → addressed by `e7a0923`.
  2. Error message degrades to `"HTTP : "` when response is fully null (low) → addressed by `8d75fc8`.
- **`/review` of expanded PR** found a downstream issue surfaced by the new fallback path:
  3. `ConvertTo-C3DApiResponse` was using boolean `-or` instead of a real fallback, so `.Error` was always `$true` (boolean) when `$ErrorMessage` was non-empty → addressed by `b6e1f61`.

## Related

- Triaged as Tier 1 in `.planning/codebase/CONCERNS.md` (Impact 5 × Likelihood 5 × Inverse Effort 5 = 125) — see PR #15 for the audit doc.
- Follow-up [SDK-496](https://linear.app/cognitive3d/issue/SDK-496/add-pester-test-coverage-for-send-c3dhttprequest-happy-and-error-paths) — adds Pester tests for `Send-C3DHttpRequest` happy/error paths and `ConvertTo-C3DApiResponse` normalization (would have caught all three bugs above before they shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)