### PR TITLE
Add LICENSE file and align README + psd1 with Cognitive3D SDK License

### DIFF
--- a/C3DUploadTools/C3DUploadTools.psd1
+++ b/C3DUploadTools/C3DUploadTools.psd1
@@ -39,8 +39,8 @@
             Tags = @('Cognitive3D', 'VR', 'Analytics', 'Upload', 'Scene', 'Objects', 'Cross-Platform')
             
             # License and project information
-            LicenseUri = 'https://github.com/cognitive3d/c3d-upload-tools/blob/main/LICENSE'
-            ProjectUri = 'https://github.com/cognitive3d/c3d-upload-tools'
+            LicenseUri = 'https://github.com/CognitiveVR/c3d-upload-tools/blob/main/LICENSE'
+            ProjectUri = 'https://github.com/CognitiveVR/c3d-upload-tools'
             IconUri = 'https://cognitive3d.com/assets/images/cognitive3d-logo.png'
             
             # Release notes

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,39 @@
+Cognitive3D SDK Software License (the “SDK License”) Copyright (c)
+2015-present CognitiveVR, Inc ("Cognitive3D")
+
+With regard to the Cognitive3D Software:
+
+This software and associated documentation files (the "Software") may only be
+used in production, if you (and any entity that you represent) have agreed to,
+and are in compliance with, the Cognitive3D Software License agreement, or
+other agreement governing the use of the Software, as agreed by you and
+Cognitive3D. Your rights to use the Software are subject to the rights and
+obligations described in such Cognitive3D Software License agreement, or other
+agreement governing the use of the Software, as agreed by you and Cognitive3D.
+Subject to the foregoing sentence, you are free to modify this Software and
+publish patches to the Software. You agree that Cognitive3D and/or its
+licensors (as applicable) retain all right, title and interest in and to all
+such modifications and/or patches, and all such modifications and/or patches
+may only be used, copied, modified, displayed, distributed, or otherwise
+exploited with a valid Cognitive3D Software License agreement. Notwithstanding
+the foregoing, you may copy and modify the Software for development and
+testing purposes, without requiring a license.  You agree that Cognitive3D
+and/or its licensors (as applicable) retain all right, title and interest in
+and to all such modifications. You hereby assign to Cognitive3D all of your
+right, title and interest in and to any modifications to the Software and
+waive in favour of Cognitive3D any moral or equivalent rights you may have in
+such modifications. You are not granted any other rights beyond what is
+expressly stated herein.  Subject to the foregoing, it is forbidden to copy,
+merge, publish, distribute, sublicense, and/or sell the Software.
+
+THE SOFTWARE IS PROVIDED ON AN "AS IS" AND “AS AVAILABLE” BASIS, WITHOUT
+WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+FOR ANY CLAIM, DAMAGES OR OTHER OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
+THE USE OR OTHER DEALINGS IN THE SOFTWARE, INCLUDING ANY SPECIAL, INDIRECT,
+INCIDENTAL OR CONSEQUENTIAL DAMAGES.
+
+For all third party components incorporated into the Cognitive3D Software,
+those components are licensed under the original license provided by the owner
+of the applicable component.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Cognitive3D SDK Software License (the “SDK License”) Copyright (c)
+Cognitive3D SDK Software License (the "SDK License") Copyright (c)
 2015-present CognitiveVR, Inc ("Cognitive3D")
 
 With regard to the Cognitive3D Software:
@@ -26,7 +26,7 @@ such modifications. You are not granted any other rights beyond what is
 expressly stated herein.  Subject to the foregoing, it is forbidden to copy,
 merge, publish, distribute, sublicense, and/or sell the Software.
 
-THE SOFTWARE IS PROVIDED ON AN "AS IS" AND “AS AVAILABLE” BASIS, WITHOUT
+THE SOFTWARE IS PROVIDED ON AN "AS IS" AND "AS AVAILABLE" BASIS, WITHOUT
 WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
 WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
 NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE

--- a/README.md
+++ b/README.md
@@ -469,7 +469,3 @@ c3d-upload-tools/
 - `scene-test/` - Complete scene for testing uploads
 - `object-test/` - Dynamic object (cube) for testing
 - `lantern-test/` - Additional object example
-
-## License
-
-This project is licensed under the MIT License. See the LICENSE file for details.


### PR DESCRIPTION
## Summary

Adds a `LICENSE` file and resolves the related discoverability/correctness gaps so the repo's licensing story is internally consistent and PowerShell Gallery–publishable.

**Four commits:**

1. **`674454a` — Add LICENSE file (original scope)**
   - Cognitive3D SDK Software License, copied from `cvr-sdk-unity/LICENSE` to keep terms consistent across SDK repos.
   - Resolves the missing target of `C3DUploadTools.psd1:42 LicenseUri` (which was 404ing).

2. **`5a09103` — Normalize LICENSE curly quotes to ASCII (Review Issue #3)**
   - Lines 1 and 29 had Unicode `U+201C/U+201D` (smart quotes) for `"SDK License"` and `"AS AVAILABLE"`, while every other quoted string used straight ASCII. Normalized for 7-bit cleanliness and consistency within this file.
   - Diverges intentionally from `cvr-sdk-unity/LICENSE` on those 4 characters — upstream still has the inconsistency. Out of scope here.

3. **`0e0fbb2` — Remove README License section (Review Issue #1)**
   - `README.md:473-475` said "This project is licensed under the **MIT License**" — a direct contradiction with the proprietary Cognitive3D SDK License this PR adds. Shipping these out-of-sync would be a real legal/clarity problem.
   - Matching `cvr-sdk-unity/readme.md` pattern: that repo has **no** license section in the README. GitHub's repo sidebar surfaces the LICENSE file directly. Removed the section here too rather than rewriting, so the two SDK repos stay consistent.

4. **`18f06ff` — Fix psd1 LicenseUri / ProjectUri org slug (Review Issue #2)**
   - Both URIs used `cognitive3d` (lowercase) as the GitHub org. Actual org is `CognitiveVR` (verified via `gh api repos/CognitiveVR/c3d-upload-tools`). Both URLs were 404ing.
   - PSGallery validates `LicenseUri` must resolve. Adding the LICENSE file (commit #1) was necessary but not sufficient — the URL had to point at it too.
   - Kept `blob/main/LICENSE` path: PSGallery publish happens after develop → main promotion, by which point the LICENSE will be on main. Future-correct for the release artifact.

## Test plan

- [x] `diff LICENSE cvr-sdk-unity/LICENSE` returns differences only on the 4 curly-quote characters
- [x] `grep -P '[^\x00-\x7F]' LICENSE` returns nothing (file is pure ASCII)
- [x] `grep -ni "mit\|licens" README.md` returns no false references (only "commit" / "limit" substring noise)
- [x] `gh api repos/CognitiveVR/c3d-upload-tools` resolves; `gh api repos/cognitive3d/c3d-upload-tools` 404s — confirms slug fix is correct
- [ ] After develop → main promotion: verify `https://github.com/CognitiveVR/c3d-upload-tools/blob/main/LICENSE` returns the LICENSE content (not 404)
- [ ] After next PSGallery publish: verify the gallery listing shows a clickable License link that opens this file

## Review history

- Initial PR: only commit `674454a`.
- `/review` of initial PR flagged three issues, all folded in:
  - Issue #1: README contradicted LICENSE → fixed by `0e0fbb2`
  - Issue #2: psd1 URLs would 404 → fixed by `18f06ff`
  - Issue #3: curly quotes inconsistency → fixed by `5a09103`

## Related

- Triaged as Tier 1 in `.planning/codebase/CONCERNS.md` (Impact 3 × Likelihood 5 × Inverse Effort 5 = 75).
- Unblocks the PowerShell Gallery publish path (CLAUDE.md: "95% Ready for Publication").

🤖 Generated with [Claude Code](https://claude.com/claude-code)