### PR TITLE
Module manifest hygiene: drop placeholder export, sync version, fix test path, refresh CLAUDE.md and ReleaseNotes

### DIFF
--- a/C3DUploadTools/C3DUploadTools.psd1
+++ b/C3DUploadTools/C3DUploadTools.psd1
@@ -1,7 +1,10 @@
 @{
     # Basic module information
     RootModule = 'C3DUploadTools.psm1'
-    ModuleVersion = '1.0.0'
+    # Keep ModuleVersion in lockstep with sdk-version.txt at the repo root.
+    # Both bash and PowerShell upload paths read sdk-version.txt to build
+    # the SDK telemetry prefix (cli-bash-v<version> / cli-powershell-v<version>).
+    ModuleVersion = '1.1.0'
     GUID = 'f4e6d8c2-1a3b-4e5f-8c7d-2e9f1a6b3c4d'
     
     # Author and company information

--- a/C3DUploadTools/C3DUploadTools.psd1
+++ b/C3DUploadTools/C3DUploadTools.psd1
@@ -49,7 +49,25 @@
             IconUri = 'https://cognitive3d.com/assets/images/cognitive3d-logo.png'
             
             # Release notes
-            ReleaseNotes = 'Initial release of PowerShell module for Cognitive3D upload tools'
+            ReleaseNotes = @'
+1.1.0
+- Fix User-Agent restricted-header crash on Windows (Send-C3DHttpRequest)
+- New Set-C3DRequestHeaders helper centralizes restricted-header handling
+- Fix Get-C3DObjects and Upload-C3DObjectManifest reading the wrong response
+  property (.Content vs .Body) - previously caused silent null/empty parses
+- Capture StatusDescription before disposing the response object
+  (HttpWebRequest error path)
+- Fall back to .Error when response Body is null so transport errors render
+  actionable messages instead of "HTTP : "
+- Fix .Error population using boolean -or instead of a real string fallback
+- Drop the Test-C3DUploads placeholder from public exports until it has a
+  real implementation
+- Add LICENSE file (Cognitive3D SDK Software License)
+- Correct LicenseUri and ProjectUri to the actual GitHub org slug
+
+1.0.0
+- Initial PowerShell module for Cognitive3D upload tools
+'@
             
             # Prerelease information (remove for stable release)
             # Prerelease = 'beta'

--- a/C3DUploadTools/C3DUploadTools.psd1
+++ b/C3DUploadTools/C3DUploadTools.psd1
@@ -19,12 +19,14 @@
     CompatiblePSEditions = @('Desktop', 'Core')
     
     # Functions to export - will be populated by the module
+    # Test-C3DUploads is not exported: still a placeholder that throws
+    # "Not implemented yet" (see Public/Test-C3DUploads.ps1). Re-add to
+    # this list once a real implementation lands.
     FunctionsToExport = @(
         'Upload-C3DScene',
-        'Upload-C3DObject', 
+        'Upload-C3DObject',
         'Upload-C3DObjectManifest',
-        'Get-C3DObjects',
-        'Test-C3DUploads'
+        'Get-C3DObjects'
     )
     
     # Cmdlets and variables to export (none for this module)

--- a/C3DUploadTools/Tests/test-module-structure.ps1
+++ b/C3DUploadTools/Tests/test-module-structure.ps1
@@ -37,7 +37,7 @@ if ($psVersion -lt [Version]'5.1') {
 
 # Test 2: Check module directory structure
 Write-Host "`n📋 Test 2: Module Directory Structure" -ForegroundColor Cyan
-$moduleRoot = Join-Path $PSScriptRoot "C3DUploadTools"
+$moduleRoot = Split-Path $PSScriptRoot -Parent
 Write-Host "Module root: $moduleRoot" -ForegroundColor Gray
 
 $requiredFiles = @(

--- a/C3DUploadTools/Tests/test-module-structure.ps1
+++ b/C3DUploadTools/Tests/test-module-structure.ps1
@@ -100,10 +100,9 @@ try {
 Write-Host "`n📋 Test 5: Exported Functions Test" -ForegroundColor Cyan
 $expectedFunctions = @(
     'Upload-C3DScene',
-    'Upload-C3DObject', 
+    'Upload-C3DObject',
     'Upload-C3DObjectManifest',
-    'Get-C3DObjects',
-    'Test-C3DUploads'
+    'Get-C3DObjects'
 )
 
 $module = Get-Module C3DUploadTools

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Generated files**: `<scene_id>_object_manifest.json` files are created automatically after object uploads
 
 ### Key Components
-- `sdk-version.txt`: Contains current SDK version (1.0.0) used for generated settings.json
+- `sdk-version.txt`: Contains current SDK version (1.1.0) used for generated settings.json. Kept in lockstep with `ModuleVersion` in `C3DUploadTools.psd1`.
 - `settings.json`: Scene configuration with scale, sceneName, and sdkVersion fields - **generated automatically** during upload with SDK prefix (`cli-bash-v<version>` or `cli-powershell-v<version>`)
 - **API endpoints**: Support both prod (cognitive3d.com) and dev (c3ddev.com) environments
 
@@ -152,7 +152,10 @@ Upload-C3DScene -SceneDirectory <path> -SceneName <name> [-Environment prod|dev]
 Upload-C3DObject -ObjectFilename <name> -ObjectDirectory <path> [-SceneId <uuid>] [-Environment prod|dev] [-DryRun]  # ✅ COMPLETE
 Upload-C3DObjectManifest [-SceneId <uuid>] [-Environment prod|dev] [-DryRun]    # ✅ COMPLETE
 Get-C3DObjects [-SceneId <uuid>] [-Environment prod|dev] [-OutputFile <path>] [-FormatAsManifest]    # ✅ COMPLETE
-Test-C3DUploads [-SceneId <uuid>] [-Environment prod|dev]    # ✅ PLACEHOLDER
+
+# Test-C3DUploads source exists at Public/Test-C3DUploads.ps1 but is intentionally
+# unexported (still a placeholder that throws). Add to FunctionsToExport in
+# C3DUploadTools.psd1 once a real implementation lands.
 
 # Environment variable support - SceneId parameter is optional when C3D_SCENE_ID is set
 ```


### PR DESCRIPTION
## Summary

Five small fixes touching the module manifest and its companion documentation. All keep the manifest, the bumped version, the test infrastructure, and the user-facing docs internally consistent.

**Five commits:**

1. **`4de40bc` — Stop exporting `Test-C3DUploads` placeholder**
   - Function body throws `"Not implemented yet"` (`Public/Test-C3DUploads.ps1:22`); having it in `Get-Command -Module C3DUploadTools` made the module look broken.
   - Dropped from `FunctionsToExport`; updated `expectedFunctions` in `test-module-structure.ps1` to match.

2. **`4299306` — Sync `ModuleVersion` 1.0.0 → 1.1.0**
   - Brings psd1 in line with `sdk-version.txt` (1.1.0). Telemetry was uploading `cli-powershell-v1.1.0` while the gallery would have advertised 1.0.0.
   - Added a comment pinning the two files together.

3. **`b54621d` — Fix `test-module-structure.ps1` path math**
   - `Join-Path $PSScriptRoot "C3DUploadTools"` pointed at `Tests/C3DUploadTools/` (doesn't exist) after the file was relocated into `Tests/`. Replaced with `Split-Path $PSScriptRoot -Parent`. Without this, Test 2 failed immediately on every run.

4. **`d6bd845` — Update `CLAUDE.md` stale references (Review Issue #1)**
   - Line 33: `sdk-version.txt` version 1.0.0 → 1.1.0, plus a note that it stays in lockstep with `ModuleVersion`.
   - Line 155: removed `Test-C3DUploads` from the "Module Usage (All Functions Complete ✅)" list; replaced with an explanatory comment noting the source file still exists (intentionally unexported) and how to re-add it once a real implementation lands.

5. **`a36590e` — Replace stale `ReleaseNotes` (Review Issue #2)**
   - psd1 still said `"Initial release of PowerShell module for Cognitive3D upload tools"` — misleading after the 1.1.0 bump. Replaced with a here-string listing the substantive 1.1.0 changes (User-Agent fix, Set-C3DRequestHeaders, Content→Body fixes, StatusDescription fix, `.Error` fallback, dropped placeholder export, LICENSE additions).
   - Validated `Test-ModuleManifest` parses cleanly and `ReleaseNotes` renders correctly.

## Test plan

- [x] `pwsh -File C3DUploadTools/Tests/test-module-structure.ps1` — all 8 tests pass; Test 5 confirms 4 exported functions (no `Test-C3DUploads`)
- [x] `Test-ModuleManifest -Path ./C3DUploadTools/C3DUploadTools.psd1` reports `Version: 1.1.0` and the new `ReleaseNotes` content
- [x] `grep -n "1\.0\.0\|Test-C3DUploads" CLAUDE.md` returns only the intentional explanatory comment
- [ ] After merge: confirm `Get-Command -Module C3DUploadTools` returns exactly 4 functions (Upload-C3DScene, Upload-C3DObject, Upload-C3DObjectManifest, Get-C3DObjects)

## Review history

- Initial PR: 3 commits (`4de40bc`, `4299306`, `b54621d`).
- `/review` flagged 4 issues; two folded in, two deferred:
  - Issue #1 (CLAUDE.md stale references) → fixed by `d6bd845`
  - Issue #2 (ReleaseNotes stale) → fixed by `a36590e`
  - Issue #3 (brittle psm1/psd1 export contract) → filed as [SDK-497](https://linear.app/cognitive3d/issue/SDK-497/make-c3duploadtoolspsm1-export-contract-explicit-dont-rely-on-psd1)
  - Issue #4 (test-module-structure Test 6 false-failure) → filed as [SDK-498](https://linear.app/cognitive3d/issue/SDK-498/fix-test-module-structureps1-test-6-false-failure-on-upload-c3dscene)

## Related

- Tier 1 entries in `.planning/codebase/CONCERNS.md` (T1.3 + T1.4, composite score 75 each).
- Follow-ups [SDK-497](https://linear.app/cognitive3d/issue/SDK-497/) and [SDK-498](https://linear.app/cognitive3d/issue/SDK-498/) for the structural concerns surfaced during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)