### PR TITLE
Refactor list-objects.sh to use upload-utils.sh helpers + clean stdout noise

### DIFF
--- a/list-objects.sh
+++ b/list-objects.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# list_scene_objects.sh - List objects for a given scene from the Cognitive3D API
+# list-objects.sh - List dynamic objects for a given scene from the Cognitive3D API
 
 set -e
 
@@ -13,29 +13,14 @@ load_env_file
 
 # --- Default values ---
 VERBOSE=false
-DEBUG=false
 SCENE_ID=""
 ENV=""
 
-# --- Helper Functions ---
-log() {
-  if [ "$VERBOSE" = true ]; then
-    echo "[INFO] $1"
-  fi
-}
-
-debug() {
-  if [ "$DEBUG" = true ]; then
-    echo "[DEBUG] $1"
-  fi
-}
-
 usage() {
-  echo "Usage: $0 [--scene_id <scene_id>] [--env <prod|dev>] [--verbose] [--debug]"
+  echo "Usage: $0 [--scene_id <scene_id>] [--env <prod|dev>] [--verbose]"
   echo "  --scene_id   Scene ID (or set C3D_SCENE_ID environment variable)"
   echo "  --env        Either 'prod' or 'dev' (or set C3D_ENV environment variable)"
   echo "  --verbose    Enable verbose logging"
-  echo "  --debug      Enable debug logging"
   echo
   echo "Environment Variables:"
   echo "  C3D_DEVELOPER_API_KEY   Your Cognitive3D developer API key"
@@ -46,15 +31,7 @@ usage() {
 }
 
 # --- Check Dependencies ---
-if ! command -v jq >/dev/null 2>&1; then
-  echo "Error: 'jq' is not installed. Please install it before running this script."
-  exit 1
-fi
-
-if ! command -v curl >/dev/null 2>&1; then
-  echo "Error: 'curl' is not installed. Please install it before running this script."
-  exit 1
-fi
+check_dependencies
 
 # --- Parse Arguments ---
 while [[ $# -gt 0 ]]; do
@@ -72,12 +49,8 @@ while [[ $# -gt 0 ]]; do
       VERBOSE=true
       shift
       ;;
-    --debug)
-      DEBUG=true
-      shift
-      ;;
     *)
-      echo "Unknown option: $1"
+      log_error "Unknown option: $1"
       usage
       ;;
   esac
@@ -87,7 +60,7 @@ done
 if [ -z "$SCENE_ID" ]; then
   SCENE_ID="${C3D_SCENE_ID:-}"
   if [ -n "$SCENE_ID" ]; then
-    log "Using C3D_SCENE_ID from environment: $SCENE_ID"
+    log_debug "Using C3D_SCENE_ID from environment: $SCENE_ID"
   fi
 fi
 
@@ -96,9 +69,9 @@ if [ -z "$ENV" ]; then
   ENV="${C3D_ENV:-${C3D_DEFAULT_ENVIRONMENT:-}}"
   if [ -n "$ENV" ]; then
     if [ -n "${C3D_ENV:-}" ]; then
-      log "Using C3D_ENV from environment: $ENV"
+      log_debug "Using C3D_ENV from environment: $ENV"
     else
-      log "Using C3D_DEFAULT_ENVIRONMENT from environment: $ENV"
+      log_debug "Using C3D_DEFAULT_ENVIRONMENT from environment: $ENV"
     fi
   fi
 fi
@@ -108,79 +81,64 @@ if [ -z "$SCENE_ID" ] || [ -z "$ENV" ]; then
   usage
 fi
 
-# --- Determine Base URL ---
-if [ "$ENV" == "prod" ]; then
-  BASE_URL="https://data.cognitive3d.com"
-elif [ "$ENV" == "dev" ]; then
-  BASE_URL="https://data.c3ddev.com"
-else
-  echo "Invalid environment: $ENV. Must be 'prod' or 'dev'."
-  exit 1
-fi
+validate_uuid_format "$SCENE_ID" "scene_id"
+validate_environment "$ENV"
+validate_api_key
 
-# --- Developer API Key (expected to be set in ENV) ---
-if [ -z "$C3D_DEVELOPER_API_KEY" ]; then
-  echo "Environment variable C3D_DEVELOPER_API_KEY is not set."
-  exit 1
-fi
+# --- Determine Base URL ---
+SCENES_BASE_URL=$(get_api_base_url "$ENV" "scenes")
+VERSIONS_BASE_URL=$(get_api_base_url "$ENV" "versions")
 
 # --- Get Scene Details ---
-SCENE_URL="$BASE_URL/v0/scenes/$SCENE_ID"
-log "Requesting scene details from $SCENE_URL"
-SCENE_RESPONSE=$(curl --silent --show-error --location \
+SCENE_URL="$SCENES_BASE_URL/$SCENE_ID"
+log_debug "Requesting scene details from $SCENE_URL"
+SCENE_RESPONSE=$(curl -s -w "\n%{http_code}" --location \
   --header "Authorization: APIKEY:DEVELOPER $C3D_DEVELOPER_API_KEY" \
-  "$SCENE_URL" -w "\nHTTP_STATUS:%{http_code}")
+  "$SCENE_URL")
 
-SCENE_BODY=$(echo "$SCENE_RESPONSE" | sed -e 's/HTTP_STATUS\:.*//g')
-SCENE_STATUS=$(echo "$SCENE_RESPONSE" | tr -d '\n' | sed -e 's/.*HTTP_STATUS://')
+parse_http_response "$SCENE_RESPONSE"
 
-if [ "$SCENE_STATUS" -ne 200 ]; then
-  echo "Error: Failed to get scene info. HTTP $SCENE_STATUS"
-  echo "$SCENE_BODY"
-  exit 1
+if [ "$HTTP_STATUS" -ne 200 ]; then
+  handle_http_error "$HTTP_STATUS" "$HTTP_BODY" "Get scene info"
 fi
 
 # --- Extract latest version id ---
-VERSION_ID=$(echo "$SCENE_BODY" | jq '.versions | max_by(.versionNumber) | .id')
+VERSION_ID=$(echo "$HTTP_BODY" | jq -r '.versions | max_by(.versionNumber) | .id')
 
 if [ -z "$VERSION_ID" ] || [ "$VERSION_ID" == "null" ]; then
-  echo "Error: Could not extract version ID from scene response."
+  log_error "Could not extract version ID from scene response."
   exit 1
 fi
 
-log "Resolved latest sceneVersionId = $VERSION_ID"
+log_debug "Resolved latest sceneVersionId = $VERSION_ID"
 
 # --- Full URL for objects ---
-URL="$BASE_URL/v0/versions/$VERSION_ID/objects"
-log "Requesting objects from $URL"
+URL="$VERSIONS_BASE_URL/$VERSION_ID/objects"
+log_debug "Requesting objects from $URL"
 
 # --- CURL Request ---
-RESPONSE=$(curl --silent --show-error --location \
+RESPONSE=$(curl -s -w "\n%{http_code}" --location \
   --header "Authorization: APIKEY:DEVELOPER $C3D_DEVELOPER_API_KEY" \
-  "$URL" -w "\nHTTP_STATUS:%{http_code}")
+  "$URL")
 
-# --- Parse Response ---
-BODY=$(echo "$RESPONSE" | sed -e 's/HTTP_STATUS\:.*//g')
-STATUS=$(echo "$RESPONSE" | tr -d '\n' | sed -e 's/.*HTTP_STATUS://')
+parse_http_response "$RESPONSE"
 
-if [ "$STATUS" -ne 200 ]; then
-  echo "Error: Received HTTP $STATUS"
-  echo "$BODY"
-  exit 1
+if [ "$HTTP_STATUS" -ne 200 ]; then
+  handle_http_error "$HTTP_STATUS" "$HTTP_BODY" "List objects"
 fi
 
 # --- Output JSON ---
 echo "Scene Objects:"
-echo "$BODY" | jq '.'
+echo "$HTTP_BODY" | jq '.'
 
 # --- Write Raw Response to File ---
 OUTPUT_FILE="${SCENE_ID}_object_list.json"
-echo "$BODY" | jq '.' > "$OUTPUT_FILE"
-log "Wrote raw output to $OUTPUT_FILE"
+echo "$HTTP_BODY" | jq '.' > "$OUTPUT_FILE"
+log_debug "Wrote raw output to $OUTPUT_FILE"
 
 # --- Write Formatted Manifest File ---
 MANIFEST_FILE="${SCENE_ID}_object_manifest.json"
-echo "$BODY" | jq '{objects: [.[] | {
+echo "$HTTP_BODY" | jq '{objects: [.[] | {
   id: .sdkId,
   mesh: .meshName,
   name: .name,
@@ -188,4 +146,4 @@ echo "$BODY" | jq '{objects: [.[] | {
   initialPosition: (.initialPosition // [0.0, 0.0, 0.0]),
   initialRotation: (.initialRotation // [0.0, 0.0, 0.0, 1.0])
 }]}' > "$MANIFEST_FILE"
-log "Wrote formatted manifest to $MANIFEST_FILE"
+log_debug "Wrote formatted manifest to $MANIFEST_FILE"

--- a/upload-utils.sh
+++ b/upload-utils.sh
@@ -97,12 +97,14 @@ check_dependencies() {
 }
 
 # Validate API key environment variable
+# Silent on success — failure-only logging keeps script output clean for piping
+# (e.g. `./list-objects.sh ... | jq` shouldn't see diagnostic lines).
 validate_api_key() {
   if [[ -z "${C3D_DEVELOPER_API_KEY:-}" ]]; then
     log_error "C3D_DEVELOPER_API_KEY is not set. Please set it with: export C3D_DEVELOPER_API_KEY=your_api_key"
     exit 1
   fi
-  log_info "C3D_DEVELOPER_API_KEY has been set."
+  log_debug "C3D_DEVELOPER_API_KEY is set."
 }
 
 # Get current scene version info from API


### PR DESCRIPTION
## Summary

Replaces local helpers in `list-objects.sh` with shared equivalents from `upload-utils.sh` (which the script already `source`d but didn't use), and folds in a small `upload-utils.sh` cleanup so all four bash scripts get a quieter stdout for piping.

**Two commits:**

1. **`832e55c` — Refactor `list-objects.sh` to use shared helpers** (original scope)
   - `log()` / `debug()` → `log_debug` (timestamped, leveled, color-coded, VERBOSE-gated)
   - Inline `jq`/`curl` checks → `check_dependencies`
   - Hand-rolled `BASE_URL` switch → `get_api_base_url`
   - Manual `sed`/`tr` HTTP response parsing → `parse_http_response`
   - Plain `echo + exit 1` on non-200 → `handle_http_error` (includes 401 expired-key guidance and HTML error-page detection)
   - Added entry validation: `validate_uuid_format`, `validate_environment`, `validate_api_key`
   - Net: `−77/+35` LOC.

2. **`3271d1e` — Silence `validate_api_key` success-case `log_info`** (Review Issue #2)
   - The success path was emitting an unconditional `[INFO] C3D_DEVELOPER_API_KEY has been set.` line on stdout (with ANSI codes), polluting every pipeline. Demoted to `log_debug` so it only fires with `--verbose`. Failure path (key unset) is unchanged.
   - Benefits **all four bash scripts** that call `validate_api_key`, not just `list-objects.sh`.

## Behavior changes (callouts)

Two changes deserve explicit attention beyond the refactor framing:

- **Defensive idiom change: `jq` → `jq -r` for `VERSION_ID` extraction.** Today's API returns numeric version IDs (e.g. `1848`), and `jq` without `-r` produces identical output to `jq -r` for numeric values — so the two forms behave the same in the current schema. The `-r` form is the correct idiom for "I want a raw scalar, not a JSON-encoded value" and remains correct if the API ever changes to string IDs (where `jq` without `-r` would emit `"abc-123"` with quotes and break URL construction). Pure defensive improvement; no live bug fix. *(Initial review framing called this a "silent bug fix" — that was wrong; corrected here.)*

- **`--debug` flag removed.** It was non-functional — no `debug()` call sites ever existed in the script body. Anyone with `--debug` baked into a wrapper, alias, or CI job will now see `[ERROR] Unknown option: --debug`. `--verbose` is the supported flag for diagnostic output.

## Test plan

- [x] `bash -n` on all four bash scripts: clean
- [x] Error paths (smoke-tested locally):
  - `./list-objects.sh` (no args) → usage + exit 1
  - `./list-objects.sh --scene_id not-a-uuid --env dev` → `[ERROR] Invalid scene_id format: not-a-uuid`
  - `./list-objects.sh --scene_id <uuid> --env staging` → `[ERROR] Invalid environment: staging. Must be 'prod' or 'dev'.`
  - `./list-objects.sh --scene_id 11111111-1111-1111-1111-111111111111 --env dev --verbose` → `[DEBUG]` line + `[ERROR] Get scene info failed with status 401` + 401-expired-key guidance
- [x] Without `--verbose`, the previous `[INFO] C3D_DEVELOPER_API_KEY has been set.` line is no longer emitted
- [x] **Live smoke against real scene** (`82dc7b38-6713-4244-8a45-a3771b7d5f41`, dev): resolved version 1848, returned 7 objects with full metadata, wrote both `*_object_list.json` and `*_object_manifest.json` artifacts. All `[DEBUG]` lines fired correctly with `--verbose`; no `[INFO]` stdout noise.

## Review history

- Initial PR: 1 commit (`832e55c`).
- `/review` flagged 5 issues:
  - Issue #1 (claimed silent `jq -r` fix) → **corrected**: not actually a live bug, the API returns numeric IDs so the two forms produced identical output. Kept as a defensive idiom change; explained in the callouts section above.
  - Issue #2 (`validate_api_key` stdout noise) → fixed by `3271d1e`
  - Issue #3 (`--debug` removal CLI surface change) → called out in this PR description
  - Issue #4 (manual smoke test) → completed against scene `82dc7b38-...` on dev
  - Issue #5 (broader stdout/stderr mixing across all bash scripts) → filed as [SDK-499](https://linear.app/cognitive3d/issue/SDK-499/route-bash-log-helpers-to-stderr-so-script-stdout-is-clean-for-piping)

## Related

- Tier 1 entry in `.planning/codebase/CONCERNS.md` (T1.5, composite score 50).
- Follow-up [SDK-499](https://linear.app/cognitive3d/issue/SDK-499/route-bash-log-helpers-to-stderr-so-script-stdout-is-clean-for-piping) — full structural fix for the stdout/stderr mixing pattern across all four bash scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)