### PR TITLE
Apply Body→Error fallback to Upload-C3DObjectManifest throw

### DIFF
--- a/C3DUploadTools/Public/Upload-C3DObjectManifest.ps1
+++ b/C3DUploadTools/Public/Upload-C3DObjectManifest.ps1
@@ -156,7 +156,8 @@ function Upload-C3DObjectManifest {
                 }
             }
         } else {
-            throw "Upload failed with HTTP $($response.StatusCode): $($response.Body)"
+            $detail = if ($response.Body) { $response.Body } else { $response.Error }
+            throw "Upload failed with HTTP $($response.StatusCode): $detail"
         }
         
         # Log execution time


### PR DESCRIPTION
## Summary

One-line fix: apply the same `if ($X.Body) { $X.Body } else { $X.Error }` fallback pattern from `Get-C3DObjects.ps1` to `Upload-C3DObjectManifest.ps1:159`.

PR #11 added this pattern to both `Get-C3DObjects.ps1` failure throws but missed the corresponding throw in `Upload-C3DObjectManifest.ps1`. On a transport-level error (DNS failure, connection refused, etc.) the normalized response object emits `StatusCode = $null`, `Body = $null`, `Error = "<exception message>"`. Without the fallback, the throw rendered as the useless `"Upload failed with HTTP : "` — the exact failure mode PR #11 was specifically eliminating.

## Diff

```diff
         } else {
-            throw "Upload failed with HTTP $($response.StatusCode): $($response.Body)"
+            $detail = if ($response.Body) { $response.Body } else { $response.Error }
+            throw "Upload failed with HTTP $($response.StatusCode): $detail"
         }
```

## How this was caught

Sonnet `/review` of PR #11 (run retroactively) noticed the inconsistency between `Get-C3DObjects.ps1`'s two fallback-using throws and the unchanged `Upload-C3DObjectManifest.ps1:159`. Pure consistency issue in the same logical change PR #11 was scoped to; missed because the original review focused on the file being primarily edited.

## Test plan

- [x] `grep -n '$.*\.Body\)' C3DUploadTools/Public/Upload-C3DObjectManifest.ps1` shows only the `if ($response.Body)` happy-path check and the fallback ternary — no remaining direct `$response.Body` consumption in throw statements
- [x] Pattern matches `Get-C3DObjects.ps1:152-153` and `:171-172` exactly
- [ ] Manual smoke test: trigger transport error (disconnect network or point at unreachable host) → throw message reads `"Upload failed with HTTP : <exception text>"` instead of `"HTTP : "`

## Related

- Follow-up to PR #11 (same bug class, same logical fix).
- Test coverage for this whole class of bug remains tracked in [SDK-496](https://linear.app/cognitive3d/issue/SDK-496/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)