### PR TITLE
Fix Codex review regressions for v1.1.0 (manifest null-id reuse, lost curl diagnostics)

### DIFF
--- a/list-objects.sh
+++ b/list-objects.sh
@@ -92,7 +92,9 @@ VERSIONS_BASE_URL=$(get_api_base_url "$ENV" "versions")
 # --- Get Scene Details ---
 SCENE_URL="$SCENES_BASE_URL/$SCENE_ID"
 log_debug "Requesting scene details from $SCENE_URL"
-SCENE_RESPONSE=$(curl -s -w "\n%{http_code}" --location \
+# --show-error keeps curl quiet on success but surfaces transport-level failures
+# (DNS, TLS, connection refused) — without it, `set -e` exits silently with no diagnostic.
+SCENE_RESPONSE=$(curl --silent --show-error -w "\n%{http_code}" --location \
   --header "Authorization: APIKEY:DEVELOPER $C3D_DEVELOPER_API_KEY" \
   "$SCENE_URL")
 
@@ -117,7 +119,8 @@ URL="$VERSIONS_BASE_URL/$VERSION_ID/objects"
 log_debug "Requesting objects from $URL"
 
 # --- CURL Request ---
-RESPONSE=$(curl -s -w "\n%{http_code}" --location \
+# --show-error keeps curl quiet on success but surfaces transport-level failures.
+RESPONSE=$(curl --silent --show-error -w "\n%{http_code}" --location \
   --header "Authorization: APIKEY:DEVELOPER $C3D_DEVELOPER_API_KEY" \
   "$URL")
 

--- a/upload-object.sh
+++ b/upload-object.sh
@@ -175,12 +175,21 @@ EOF
       local EXISTING_ID
       EXISTING_ID=$(jq -r --arg mesh "$OBJECT_FILENAME" \
         '.objects[] | select(.mesh == $mesh) | .id' "$MANIFEST_FILE_CHECK" 2>/dev/null | head -1)
-      if [[ -n "$EXISTING_ID" ]]; then
+      # Validate before reuse: jq -r emits the literal string "null" for JSON null,
+      # and stale or hand-authored manifests may have non-UUID values. Reusing such
+      # values would write "/objects/<scene>/null" to the server and corrupt state.
+      # Fall through to uuidgen unless we have a real UUID.
+      if [[ -n "$EXISTING_ID" ]] && [[ "$EXISTING_ID" != "null" ]] \
+          && [[ "$EXISTING_ID" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
         OBJECT_ID="$EXISTING_ID"
         log_info "Reusing existing object ID from manifest: $OBJECT_ID"
       else
         OBJECT_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
-        log_debug "No existing manifest entry for mesh '$OBJECT_FILENAME', generated UUID: $OBJECT_ID"
+        if [[ -n "$EXISTING_ID" ]] && [[ "$EXISTING_ID" != "null" ]]; then
+          log_warn "Manifest entry for mesh '$OBJECT_FILENAME' has non-UUID id '$EXISTING_ID'; generating new UUID: $OBJECT_ID"
+        else
+          log_debug "No reusable manifest entry for mesh '$OBJECT_FILENAME', generated UUID: $OBJECT_ID"
+        fi
       fi
     else
       OBJECT_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
## Summary

Two small bash fixes addressing regressions Codex flagged when reviewing `release/v1.1.0` against `main`. Both are regressions introduced earlier in the v1.1.0 batch — folding the fixes in here so they ship together rather than chasing a follow-up release.

**Two commits:**

1. **`1da3735` — Reject null/non-UUID manifest IDs before reuse (P2)**
   - `upload-object.sh:176-188` — the manifest-ID reuse logic introduced in PR #10's idempotency fold-in passed `[[ -n "$EXISTING_ID" ]]` for the literal 4-char string `"null"` (what `jq -r` returns for JSON `null`). Result: `OBJECT_ID="null"`, upload URL becomes `/objects/<scene>/null`, and the manifest gets written with `"id": "null"`. Silent server-state corruption.
   - Fix: require non-empty, not `"null"`, AND a UUID regex match before reuse. Fall through to `uuidgen` otherwise. Log `log_warn` on non-UUID manifest entries so users see the bad data they have.
   - Regex matrix verified for `""`, `"null"`, `"abc-123"`, valid UUID (lowercase + uppercase), trailing junk, short last segment.

2. **`aa40875` — Restore `--show-error` on list-objects.sh curl calls (P3)**
   - `list-objects.sh:95-97, 119-122` — PR #14's refactor swapped `curl --silent --show-error` for `curl -s`. With just `-s`, curl is fully silent on transport-level failures (DNS, TLS, connection refused). Combined with `set -e`, the script exits silently with no diagnostic.
   - Fix: use `curl --silent --show-error` (the canonical "quiet on success, loud on failure" combination) on both curl invocations. Added a comment explaining the intent so it isn't simplified back to `-s` by a future refactor.
   - Demonstrated locally: `curl -s http://127.0.0.1:65535/test` → no output; `curl --silent --show-error http://127.0.0.1:65535/test` → `curl: (7) Failed to connect to 127.0.0.1 port 65535 after 0 ms: Couldn't connect to server`.

## Test plan

- [x] `bash -n upload-object.sh list-objects.sh` clean
- [x] UUID regex matrix passes (see P2 commit message for verified cases)
- [x] Transport-error demonstration confirms `--show-error` surfaces curl's diagnostic
- [ ] After merge to develop: re-squash `release/v1.1.0` and force-push-with-lease so PR #16 picks up these fixes before promotion to main

## How this was caught

Codex `/codex:review --base main` against `release/v1.1.0` flagged both items as P2/P3 regressions in edge/error paths that would ship to main with v1.1.0. Both are regressions I introduced earlier in this batch (P2 in PR #10's idempotency fold-in, P3 in PR #14's refactor), so folding the fixes in before promotion rather than shipping as known issues.

## Related

- Same review-then-fold-in pattern as PR #17 (Body→Error fallback consistency, caught by Sonnet's retroactive `/review` of PR #11).
- Test coverage for these error paths remains tracked in [SDK-496](https://linear.app/cognitive3d/issue/SDK-496/) (Pester) and would benefit from corresponding bash test fixtures — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)