### PR TITLE
SDK-500: Strip surrounding quotes in bash load_env_file to match PowerShell

### DIFF
--- a/test-scripts/test-env-loader.sh
+++ b/test-scripts/test-env-loader.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+# test-env-loader.sh
+#
+# Unit tests for upload-utils.sh::load_env_file's value-parsing behavior.
+# Specifically covers the SDK-500 quote-stripping fix: bash and PowerShell
+# must agree on how to parse quoted .env values, otherwise users hit a
+# silent 401 on bash (because the literal quotes get sent in the
+# Authorization header) while PowerShell works fine on the same .env file.
+
+set -euo pipefail
+
+# Change to repo root (parent of test-scripts/)
+cd "$(dirname "$0")/.."
+
+source ./test-scripts/test-utils.sh
+
+# load_env_file refuses to overwrite already-set variables — every test
+# needs to run in a fresh bash subshell so prior assignments don't leak.
+# Helper: run load_env_file against a fixture and print the value of one variable.
+run_loader() {
+  local fixture="$1"
+  local var_name="$2"
+  bash -c "
+    set -e
+    source ./upload-utils.sh
+    load_env_file '$fixture' >/dev/null 2>&1
+    printf '%s' \"\${$var_name}\"
+  "
+}
+
+# Helper: assert exported value matches expected exactly.
+assert_value() {
+  local label="$1"
+  local fixture="$2"
+  local var_name="$3"
+  local expected="$4"
+
+  print_test "$TESTS_TOTAL" "$label"
+  local actual
+  actual=$(run_loader "$fixture" "$var_name")
+  if [[ "$actual" == "$expected" ]]; then
+    print_pass "$label (got [$actual])"
+  else
+    print_fail "$label — expected [$expected], got [$actual]"
+  fi
+}
+
+# ============================================================
+# Fixture construction
+# ============================================================
+
+FIXTURE=$(mktemp)
+trap 'rm -f "$FIXTURE"' EXIT
+
+cat > "$FIXTURE" <<'EOF'
+# A comment line at top
+BARE=abc123
+DOUBLE_QUOTED="def456"
+SINGLE_QUOTED='ghi789'
+EMPTY_BARE=
+EMPTY_DOUBLE=""
+EMPTY_SINGLE=''
+EMBEDDED_EQUALS="key=val=more"
+EMBEDDED_SPACES="hello world"
+LEADING_TRAILING_SPACES="  spaces  "
+DOUBLE_INNER_SINGLE="it's quoted"
+SINGLE_INNER_DOUBLE='he said "hi"'
+   INDENTED_KEY=indented_value
+# Comment in the middle
+ASYMMETRIC_DOUBLE_LEFT="oops
+ASYMMETRIC_DOUBLE_RIGHT=oops"
+ASYMMETRIC_MIXED="foo'
+NUMERIC_QUOTED="42"
+EOF
+
+# ============================================================
+# Tests
+# ============================================================
+
+print_section "load_env_file value parsing (SDK-500 quote-stripping)"
+
+# Happy-path: bare, no quotes
+assert_value "bare value (no quotes)"             "$FIXTURE" BARE                       "abc123"
+
+# Quote stripping
+assert_value "double-quoted value"                "$FIXTURE" DOUBLE_QUOTED              "def456"
+assert_value "single-quoted value"                "$FIXTURE" SINGLE_QUOTED              "ghi789"
+assert_value "double-quoted numeric"              "$FIXTURE" NUMERIC_QUOTED             "42"
+
+# Empty value edge cases
+assert_value "bare empty"                         "$FIXTURE" EMPTY_BARE                 ""
+assert_value "double-quoted empty"                "$FIXTURE" EMPTY_DOUBLE               ""
+assert_value "single-quoted empty"                "$FIXTURE" EMPTY_SINGLE               ""
+
+# Embedded characters preserved inside quotes
+assert_value "embedded equals signs"              "$FIXTURE" EMBEDDED_EQUALS            "key=val=more"
+assert_value "embedded spaces"                    "$FIXTURE" EMBEDDED_SPACES            "hello world"
+assert_value "preserved inner spaces (no trim)"   "$FIXTURE" LEADING_TRAILING_SPACES    "  spaces  "
+
+# Mixed inner quotes preserved
+assert_value "double-quoted with inner single"    "$FIXTURE" DOUBLE_INNER_SINGLE        "it's quoted"
+assert_value "single-quoted with inner double"    "$FIXTURE" SINGLE_INNER_DOUBLE        'he said "hi"'
+
+# Indented key still parses (existing trim behavior)
+assert_value "leading-whitespace key"             "$FIXTURE" INDENTED_KEY               "indented_value"
+
+# Asymmetric / malformed quotes — do NOT strip; preserve literal
+assert_value "left-only double quote (preserved)" "$FIXTURE" ASYMMETRIC_DOUBLE_LEFT     '"oops'
+assert_value "right-only double quote (preserved)" "$FIXTURE" ASYMMETRIC_DOUBLE_RIGHT   'oops"'
+assert_value "asymmetric mixed quotes (preserved)" "$FIXTURE" ASYMMETRIC_MIXED          "\"foo'"
+
+# ============================================================
+# Summary
+# ============================================================
+
+print_section "Results"
+echo "Tests passed: $TESTS_PASSED / $TESTS_TOTAL"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+  echo "Tests failed: $TESTS_FAILED"
+  exit 1
+fi

--- a/test-scripts/test-env-loader.sh
+++ b/test-scripts/test-env-loader.sh
@@ -18,14 +18,23 @@ source ./test-scripts/test-utils.sh
 # load_env_file refuses to overwrite already-set variables — every test
 # needs to run in a fresh bash subshell so prior assignments don't leak.
 # Helper: run load_env_file against a fixture and print the value of one variable.
+#
+# Failure modes use distinctive sentinels so a future regression in
+# load_env_file can't silently masquerade as the expected empty-string value
+# in the empty-value test cases:
+#   - load_env_file fails:                         prints __LOAD_FAILED__
+#   - load_env_file succeeds but variable unset:   prints __UNSET__
+#   - load_env_file succeeds and variable set:     prints the value
 run_loader() {
   local fixture="$1"
   local var_name="$2"
   bash -c "
-    set -e
     source ./upload-utils.sh
-    load_env_file '$fixture' >/dev/null 2>&1
-    printf '%s' \"\${$var_name}\"
+    if ! load_env_file '$fixture' >/dev/null 2>&1; then
+      printf '__LOAD_FAILED__'
+      exit 0
+    fi
+    printf '%s' \"\${$var_name-__UNSET__}\"
   "
 }
 

--- a/upload-utils.sh
+++ b/upload-utils.sh
@@ -51,7 +51,18 @@ load_env_file() {
       # Trim whitespace
       key=$(echo "$key" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
       value=$(echo "$value" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-      
+
+      # Strip surrounding double or single quotes to match the PowerShell
+      # Import-C3DEnvironment behavior. Without this, a value like
+      # `C3D_DEVELOPER_API_KEY="abc123"` exports the literal `"abc123"`
+      # (with quotes) and the resulting Authorization header reads
+      # `APIKEY:DEVELOPER "abc123"` — the server returns 401 with the
+      # misleading "invalid key" message even though the key is right.
+      # See SDK-500.
+      if [[ "$value" =~ ^\"(.*)\"$ ]] || [[ "$value" =~ ^\'(.*)\'$ ]]; then
+        value="${BASH_REMATCH[1]}"
+      fi
+
       # Skip if key is empty
       [[ -z "$key" ]] && continue
       


### PR DESCRIPTION
## Summary

Resolves [SDK-500](https://linear.app/cognitive3d/issue/SDK-500/) — the bash↔PowerShell `.env`-loader divergence that caused silent 401 auth failures on bash for any user with quoted values in `.env`.

## The bug

Bash `load_env_file` (`upload-utils.sh:31-77`) and PowerShell `Import-C3DEnvironment.ps1:29-33` parsed `.env` files differently:

| `.env` content | Bash export | PowerShell export |
|---|---|---|
| `KEY="abc123"` | `"abc123"` (literal quotes) | `abc123` |
| `KEY='abc123'` | `'abc123'` (literal quotes) | `abc123` |
| `KEY=abc123` | `abc123` | `abc123` |

The bash side then built `Authorization: APIKEY:DEVELOPER "abc123"` (with literal quotes) and the server returned **401 Unauthorized** with the misleading "invalid key" / "expired key" guidance from `handle_http_error`. Same key, same `.env` file — works on PowerShell, fails on bash. No diagnostic pointing at quoting as the cause.

This was plausibly the highest-impact silent-failure bug in the repo: any user following conventional `.env` patterns (Docker, Node, dotenv-style password manager exports) would hit it on bash but not PowerShell.

## The fix

```bash
# Strip surrounding double or single quotes to match PowerShell behavior.
if [[ "$value" =~ ^\"(.*)\"$ ]] || [[ "$value" =~ ^\'(.*)\'$ ]]; then
  value="${BASH_REMATCH[1]}"
fi
```

Greedy `.*` correctly captures across embedded `=` and embedded inner quotes. Asymmetric / single-quote-only values are **not** stripped (preserved literal) — both the regex `^"..."$` and PowerShell's `StartsWith/EndsWith` check require matching delimiters on both ends.

Placed immediately after the existing whitespace trim, so the order is: trim → strip quotes → validate key format → export.

## Test plan

New `test-scripts/test-env-loader.sh` covers a 16-case matrix:

**Happy:** bare, double-quoted, single-quoted, numeric-quoted
**Empty:** bare, double-quoted empty, single-quoted empty
**Preserved content:** embedded `=`, embedded spaces, leading/trailing inner whitespace, mixed inner quotes (single in double, double in single)
**Regression guard:** indented key (existing trim behavior)
**Malformed/asymmetric (preserved literal, NOT stripped):** left-only `"oops`, right-only `oops"`, mixed `"foo'`

- [x] All 16 tests pass: `./test-scripts/test-env-loader.sh`
- [x] `bash -n upload-utils.sh test-scripts/test-env-loader.sh` clean
- [x] Manual matrix verified (`BARE=abc123`, `DOUBLE_QUOTED="def456"`, `EMBEDDED_EQUALS="key=val=more"` all parse correctly)
- [ ] After merge to develop: regenerate `release/v1.1.0`'s squash to pick this up for the next main promotion (or schedule as v1.1.1)

## Parity with PowerShell

Verified the fix matches `Import-C3DEnvironment.ps1`'s behavior for all common cases. One known divergence: PowerShell's implementation throws `ArgumentOutOfRangeException` on a single-character `"` value (`Substring(1, -1)`); bash regex requires length ≥ 2 so it preserves the literal. Out of scope for this PR — would require touching the PS side too. Filed for tracking purposes only; no actual user impact.

## Related

- [SDK-500](https://linear.app/cognitive3d/issue/SDK-500/) (High priority, 3 pts) — surfaced during Sonnet `/review` of PR #15.
- Was previously documented as a behavioral divergence in `.planning/codebase/CONCERNS.md` and `CONVENTIONS.md` (develop only).
- Adjacent to [SDK-501](https://linear.app/cognitive3d/issue/SDK-501/) (curl --show-error everywhere) — separate bash UX cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)